### PR TITLE
[Feat] Allows overlay touch to not passthrough

### DIFF
--- a/Source/CoachMarksController.swift
+++ b/Source/CoachMarksController.swift
@@ -100,6 +100,16 @@ public class CoachMarksController: UIViewController, OverlayViewDelegate {
         }
     }
 
+    public var cutoutPathShouldPassTouches: Bool {
+        get {
+            return overlayView.cutoutPathShouldPassTouches
+        }
+
+        set {
+            overlayView.cutoutPathShouldPassTouches = newValue
+        }
+    }
+
     /// The view holding the "Skip" control
     public var skipView: CoachMarkSkipView? {
         // Again, we test the protocol/UIView combination

--- a/Source/OverlayView.swift
+++ b/Source/OverlayView.swift
@@ -60,6 +60,8 @@ internal class OverlayView: UIView {
         }
     }
 
+    var cutoutPathShouldPassTouches = false
+
     /// Used to temporarily disable the tap, for a given coachmark.
     var disableOverlayTap: Bool = false
 
@@ -214,7 +216,7 @@ internal class OverlayView: UIView {
     override func hitTest(point: CGPoint, withEvent event: UIEvent?) -> UIView? {
         let hitView = super.hitTest(point, withEvent: event)
 
-        if hitView == self {
+        if cutoutPathShouldPassTouches && hitView == self {
             guard let cutoutPath = self.cutoutPath else {
                 return hitView
             }


### PR DESCRIPTION
Reverts the new change that allows touches to be passed to subview on `OverlayView`
